### PR TITLE
Fix base64 key decoding and add self-destruct test

### DIFF
--- a/self-destruct.py
+++ b/self-destruct.py
@@ -10,6 +10,7 @@ import argparse
 from argparse import RawTextHelpFormatter
 import base64
 import time
+import ast
 
 pwd = os.getcwd()
 
@@ -28,10 +29,10 @@ expired = False
 wrong_secret = False
 
 try:
-    b64decoded = base64.b64decode(args.key)
-    decoded_list = b64decoded.strip('][').replace("'", "").split(', ')
-    decoded = bytes.decode(decoded_list[0])
-    expiry_time = datetime.datetime.fromtimestamp(int(float(decoded)))
+    decoded_bytes = base64.b64decode(args.key)
+    decoded_str = decoded_bytes.decode('utf-8')
+    decoded_list = ast.literal_eval(decoded_str)
+    expiry_time = datetime.datetime.fromtimestamp(int(float(decoded_list[0])))
     now_tuple = now.timetuple()
     timestamp = time.mktime(now_tuple)
     today = datetime.datetime.fromtimestamp(int(float(timestamp)))
@@ -48,9 +49,8 @@ except:
 if args.fakeout:
     print("Debugging..")
     print("now:",now)
-    print("b64decoded:",b64decoded)
+    print("b64decoded:",decoded_bytes)
     print("decoded_list",decoded_list)
-    print("decoded:",decoded)
     print("expiry_time:",expiry_time)
     print("now_tuple:",now_tuple)
     print("timestamp:",timestamp)

--- a/tests/test_self_destruct.py
+++ b/tests/test_self_destruct.py
@@ -1,0 +1,19 @@
+import subprocess
+import sys
+import re
+
+
+def get_generated_key():
+    proc = subprocess.run([sys.executable, 'generate_key.py'], capture_output=True, text=True)
+    assert proc.returncode == 0, proc.stderr
+    match = re.search(r"Generated Key: (.+)", proc.stdout)
+    assert match, "Key not found in output"
+    return match.group(1).strip()
+
+
+def test_generated_key_is_valid():
+    key = get_generated_key()
+    proc = subprocess.run([sys.executable, 'self-destruct.py', '-k', key, '-f'], capture_output=True, text=True)
+    assert proc.returncode == 0, proc.stderr
+    assert 'destroy: False' in proc.stdout
+    assert 'wrong_secret: False' in proc.stdout


### PR DESCRIPTION
## Summary
- correctly decode and parse keys in `self-destruct.py`
- add unit test ensuring a generated key is accepted

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_686c5ccfb95c8326949d9048ab96d50e