### PR TITLE
Remove global declaration for args

### DIFF
--- a/self-destruct.py
+++ b/self-destruct.py
@@ -19,7 +19,6 @@ parser = argparse.ArgumentParser(description='Self Destruct',formatter_class=Raw
 parser.add_argument('-k', '--key', dest='key',  type=str, required=True, help='Safety Key.', metavar='<key>')
 parser.add_argument('-f', '--fakeout', dest='fakeout', action='store_true', required=False, help=argparse.SUPPRESS)
 
-global args
 args = parser.parse_args()
 
 now = datetime.date.today()


### PR DESCRIPTION
## Summary
- drop unnecessary `global args` declaration
- keep argument parsing at module scope

## Testing
- `python3 -m py_compile self-destruct.py generate_key.py`


------
https://chatgpt.com/codex/tasks/task_e_686c5e3b746c8326b60d54a4491038d6