### PR TITLE
Improve self-destruct error handling

### DIFF
--- a/self-destruct.py
+++ b/self-destruct.py
@@ -9,6 +9,7 @@ import os
 import argparse
 from argparse import RawTextHelpFormatter
 import base64
+import binascii
 import time
 
 pwd = os.getcwd()
@@ -41,8 +42,8 @@ try:
     if decoded_list[1] != "random_key":
         wrong_secret = True
         destroy = True
-except:
-    print("There is a problem with the key!")
+except (ValueError, binascii.Error) as exc:
+    print(f"There is a problem with the key: {exc}")
     sys.exit(1)
 
 if args.fakeout:

--- a/tests/test_self_destruct.py
+++ b/tests/test_self_destruct.py
@@ -1,0 +1,10 @@
+import subprocess
+import sys
+from pathlib import Path
+
+
+def test_malformed_key_exit():
+    script = Path(__file__).resolve().parents[1] / "self-destruct.py"
+    result = subprocess.run([sys.executable, str(script), "-k", "invalidkey"], capture_output=True)
+    assert result.returncode == 1
+    assert b"There is a problem with the key" in result.stdout


### PR DESCRIPTION
## Summary
- catch specific decoding errors in `self-destruct.py`
- report the error message for debugging
- add regression test for malformed key handling

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_686c62629a7c8326b209142cae91bd80