### PR TITLE
Use context manager in self-destruct

### DIFF
--- a/self-destruct.py
+++ b/self-destruct.py
@@ -62,15 +62,14 @@ elif destroy:
     print("This script has expired and will now self-destruct.")
     print("Removing %s..."%sys.argv[0])
     if sys.platform == "win32":
-        delbat = open("c:\\temp\\_{0}.bat".format(args.key),'w+')
-        delbat.write('''
+        with open("c:\\temp\\_{0}.bat".format(args.key), 'w', encoding='utf-8') as delbat:
+            delbat.write('''
                         @echo off
                         :Repeat
                         del "{0}" > nul 2> nul
                         if exist "{0}" goto Repeat
                         del "c:\temp\_{1}.bat";
                     '''.format(sys.argv[0],args.key))
-        delbat.close()
         os.startfile(r"c:\temp\_{0}.bat".format(args.key))
     else: # Linux Desktop
         os.remove("%s"%sys.argv[0])


### PR DESCRIPTION
## Summary
- use a context manager when writing the cleanup `.bat` file
- drop manual file close
- ensure `self-destruct.py` ends with a newline

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_686c63427ccc832692c635fc07cab35c