### PR TITLE
Fix flake8 warnings in generate_key.py

### DIFF
--- a/generate_key.py
+++ b/generate_key.py
@@ -8,8 +8,7 @@ import datetime
 import base64
 import sys
 import time
-  
- 
+
 now = datetime.date.today()
 days = 30
 future = now + datetime.timedelta(days=days)
@@ -17,13 +16,13 @@ expiry = future.timetuple()
 
 timestamp = time.mktime(expiry)
 
-print("Generating key, expiry date: ",future)
-secret = [ timestamp, "random_key" ]
+print("Generating key, expiry date: ", future)
+secret = [timestamp, "random_key"]
 
-b64key= base64.b64encode(str(secret).encode('utf-8'))
+b64key = base64.b64encode(str(secret).encode('utf-8'))
 key = bytes.decode(b64key)
 
-print("Generated Key: %s\n"%key)
-print("Key will expire in %i days."%days)
+print("Generated Key: %s\n" % key)
+print("Key will expire in %i days." % days)
 
 sys.exit(0)


### PR DESCRIPTION
## Summary
- clean whitespace in `generate_key.py`
- make formatting consistent

## Testing
- `flake8 generate_key.py`

------
https://chatgpt.com/codex/tasks/task_e_686c640e10dc8326942deb09fda0dd82