### PR TITLE
Add usage docs and tests

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,5 +1,32 @@
 # Self Destruct
  
- Self-destruct function for use in other projects, or temporary granting of use.
- 
- CAUTION: This script will self-destruct without a key! Do not commit changes if accidentally run.
+  Self-destruct function for use in other projects, or temporary granting of use.
+
+  CAUTION: This script will self-destruct without a key! Do not commit changes if accidentally run.
+
+## Generating and Using a Key
+
+1. Run `generate_key.py` to create a key with a 30 day lifetime:
+
+   ```bash
+   $ python3 generate_key.py
+   Generating key, expiry date:  <date>
+   Generated Key: <base64 string>
+
+   Key will expire in 30 days.
+   ```
+
+   The produced key is a base64 encoded Python list in the form
+   `[TIMESTAMP, 'random_key']`. `TIMESTAMP` is a Unix epoch value denoting the
+   expiration time.
+
+2. Supply the key to `self-destruct.py`:
+
+   ```bash
+   $ python3 self-destruct.py -k <base64 key>
+   ```
+
+   Use `--fakeout` to display debugging output instead of deleting the file.
+
+`self-destruct.py` compares the timestamp with the current date and removes
+itself when the key has expired.

--- a/self-destruct.py
+++ b/self-destruct.py
@@ -29,8 +29,11 @@ wrong_secret = False
 
 try:
     b64decoded = base64.b64decode(args.key)
-    decoded_list = b64decoded.strip('][').replace("'", "").split(', ')
-    decoded = bytes.decode(decoded_list[0])
+    # base64 decode returns bytes under Python 3.  Convert to a string
+    # before processing the list representation.
+    decoded_str = b64decoded.decode('utf-8')
+    decoded_list = decoded_str.strip('[]').replace("'", "").split(', ')
+    decoded = decoded_list[0]
     expiry_time = datetime.datetime.fromtimestamp(int(float(decoded)))
     now_tuple = now.timetuple()
     timestamp = time.mktime(now_tuple)

--- a/tests/test_scripts.py
+++ b/tests/test_scripts.py
@@ -1,0 +1,17 @@
+import subprocess
+import sys
+import re
+
+REPO_ROOT = sys.path[0]
+
+def run_cmd(args):
+    return subprocess.run(args, stdout=subprocess.PIPE, stderr=subprocess.STDOUT, text=True, check=True)
+
+def test_generate_and_fakeout():
+    result = run_cmd([sys.executable, 'generate_key.py'])
+    assert 'Generated Key:' in result.stdout
+    match = re.search(r'Generated Key:\s*(\S+)', result.stdout)
+    assert match, 'key not found'
+    key = match.group(1)
+    fake = run_cmd([sys.executable, 'self-destruct.py', '--fakeout', '-k', key])
+    assert 'Debugging..' in fake.stdout


### PR DESCRIPTION
## Summary
- document how to generate keys and invoke `self-destruct.py`
- fix base64 decoding logic for Python 3
- add a minimal pytest checking key generation and debug mode

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_686c64bc8e54832691759bf5c11eae24